### PR TITLE
Updated progress message with a real-time percentage

### DIFF
--- a/src/count.sh
+++ b/src/count.sh
@@ -1,0 +1,14 @@
+conclude()
+{
+    printf '%d' $cases
+}
+
+run_test()
+{
+    cases=$((cases + 1))
+}
+
+if [ -z $cases ]
+then
+    cases=0
+fi

--- a/src/injections/override.sh
+++ b/src/injections/override.sh
@@ -32,6 +32,8 @@ pass()
             progress
         fi
     fi
+
+    case=$((case + 1))
 }
 
 fail()
@@ -62,6 +64,8 @@ fail()
             progress
         fi
     fi
+
+    case=$((case + 1))
 }
 
 conclude()
@@ -76,7 +80,8 @@ conclude()
 
 progress()
 {
-    printf '\033[2K\015...%s@%d' "$hint" $count 1>&2
+    percent=`printf "scale=1; $case*100/$CASES\n" | bc`
+    printf '\033[2K\015%s%%' "$percent" 1>&2
 }
 
 current_seconds()
@@ -87,4 +92,9 @@ current_seconds()
 if [ -z $start_seconds ]
 then
     start_seconds=`current_seconds`
+fi
+
+if [ -z $case ]
+then
+    case=0
 fi


### PR DESCRIPTION
Added a pre-processing step to count the number of cases that are available for testing then used it for a percentage in the progress message.