### PR TITLE
Fixed progress message showing up in error message

### DIFF
--- a/src/injections/file.sh
+++ b/src/injections/file.sh
@@ -11,6 +11,7 @@ run_file_test()
 
     if [ $actual_code != $expected_code ]
     then
+        printf '\033[2K\015' 1>&2
         printf '[ERROR] Test case returned an unexpected exit code.\n' 1>&2
         printf 'Hint: %s\n' "$hint" 1>&2
         printf 'Source: %s\n' "$text" 1>&2
@@ -21,6 +22,7 @@ run_file_test()
 
     if [ "$actual_output" != "$expected_output" ]
     then
+        printf '\033[2K\015' 1>&2
         printf '[ERROR] Test case returned an unexpected stdout.\n' 1>&2
         printf 'Hint: %s\n' "$hint" 1>&2
         printf 'Source: %s\n' "$text" 1>&2

--- a/src/injections/interactive.sh
+++ b/src/injections/interactive.sh
@@ -23,6 +23,7 @@ run_interactive_test()
 
     if [ $actual_code != $expected_code ]
     then
+        printf '\033[2K\015' 1>&2
         printf '[ERROR] Test case returned an unexpected exit code.\n' 1>&2
         printf 'Hint: %s\n' "$hint" 1>&2
         printf 'Source: %s\n' "$text" 1>&2
@@ -33,6 +34,7 @@ run_interactive_test()
 
     if [ "$actual_output" != "$expected_output" ]
     then
+        printf '\033[2K\015' 1>&2
         printf '[ERROR] Test case returned an unexpected stdout.\n' 1>&2
         printf 'Hint: %s\n' "$hint" 1>&2
         printf 'Source: %s\n' "$text" 1>&2

--- a/src/injections/memory.sh
+++ b/src/injections/memory.sh
@@ -7,6 +7,7 @@ run_memory_test()
 
     if [ $code -ne 0 -a $code -ne 1 ]
     then
+        printf '\033[2K\015' 1>&2
         printf '[ERROR] Test case failed memory leak test.\n' 1>&2
         printf 'Hint: %s\n' "$hint" 1>&2
         printf 'Source: %s\n' "$text" 1>&2

--- a/src/injections/override.sh
+++ b/src/injections/override.sh
@@ -71,6 +71,40 @@ conclude()
     count=0
 }
 
+run_test()
+{
+    text=$1
+    expected_output=$2
+    expected_code=$3
+
+    actual_output=`$PROGRAM -t "$text"`
+    actual_code=$?
+
+    if [ $actual_code != $expected_code ]
+    then
+        printf '\033[2K\015' 1>&2
+        printf '[ERROR] Test case returned an unexpected exit code.\n' 1>&2
+        printf 'Hint: %s\n' "$hint" 1>&2
+        printf 'Source: %s\n' "$text" 1>&2
+        printf 'Expected: %d\n' $expected_code 1>&2
+        printf 'Actual: %d\n' $actual_code 1>&2
+        exit 1
+    fi
+
+    if [ "$actual_output" != "$expected_output" ]
+    then
+        printf '\033[2K\015' 1>&2
+        printf '[ERROR] Test case returned an unexpected stdout.\n' 1>&2
+        printf 'Hint: %s\n' "$hint" 1>&2
+        printf 'Source: %s\n' "$text" 1>&2
+        printf 'Expected: %s\n' "$expected_output" 1>&2
+        printf 'Actual: %s\n' "$actual_output" 1>&2
+        exit 1
+    fi
+
+    count=$((count + 1))
+}
+
 progress()
 {
     percent=`printf "scale=0; $case*100/$CASES\n" | bc`


### PR DESCRIPTION
Fixed the progress message showing up in the error message when a test case fails.